### PR TITLE
Fix Risc-V build

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -135,7 +135,7 @@ parts:
     stage-packages:
       - libgusb2
       - libpackagekit-glib2-18
-      - libieee1284-3
+      - libieee1284-3t64
 
   cleanup:
     after: [ libs ]


### PR DESCRIPTION
For some reason, risc-V systems don't replace libieee1284-3 package with libieee1284-3t64 when using APT, so snapping fails because that package doesn't exist anymore.

This patch fixes the package name.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please check only the options that are relevant.

- [ ] General Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:

* OS (please include version):
* Any other relevant environment information:

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings

